### PR TITLE
Set confirmed to true for all first time users

### DIFF
--- a/qa-open-login.php
+++ b/qa-open-login.php
@@ -111,7 +111,7 @@ class qa_open_login
 					$duplicates = qa_log_in_external_user($key, $user->identifier, array(
 						'email' => @$user->email,
 						'handle' => @$user->displayName,
-						'confirmed' => !empty($user->emailVerified),
+						'confirmed' => true,
 						'name' => @$user->displayName,
 						'location' => @$user->region,
 						'website' => @$user->webSiteURL,


### PR DESCRIPTION
# Description
Currently, users are asked to confirm their email but emails do not work in Overflow due to SMTP not being configured. This PR ensures that all users have created with email address confirmed set to true. The user is coming from Okta, we know that their email is valid.


# Task
https://jira.redventures.net/browse/DEVX-1982